### PR TITLE
notify: add a channel to the home assistant notification

### DIFF
--- a/src/notify.ts
+++ b/src/notify.ts
@@ -13,7 +13,7 @@ export class NotifyDevice extends ScryptedDeviceBase implements Notifier {
         let image: string;
         let data: any = {
             priority: 'high',
-            channel: 'scrypted',
+            channel: 'scrypted'
         };
 
         if (typeof media === 'string') {
@@ -56,6 +56,10 @@ export class NotifyDevice extends ScryptedDeviceBase implements Notifier {
 
         if (image)
             data.image = image;
+
+         // Append the channel to the default 'scrypted' channel, if specified
+        if (options?.channel && options?.channel.length > 0)
+            data.channel += "_" + options.channel
 
         if (options?.data?.ha)
             Object.assign(data, options.data.ha)

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -13,7 +13,6 @@ export class NotifyDevice extends ScryptedDeviceBase implements Notifier {
         let image: string;
         let data: any = {
             priority: 'high',
-            channel: 'scrypted'
         };
 
         if (typeof media === 'string') {
@@ -57,9 +56,10 @@ export class NotifyDevice extends ScryptedDeviceBase implements Notifier {
         if (image)
             data.image = image;
 
-         // Append the channel to the default 'scrypted' channel, if specified
-        if (options?.channel && options?.channel.length > 0)
-            data.channel += "_" + options.channel
+        // Append the channel to the default 'scrypted' channel, if specified
+        data.channel = 'scrypted'
+        if (options?.android?.channel && options?.android?.channel.length > 0)
+            data.channel += "_" + options.android.channel
 
         if (options?.data?.ha)
             Object.assign(data, options.data.ha)

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -13,6 +13,7 @@ export class NotifyDevice extends ScryptedDeviceBase implements Notifier {
         let image: string;
         let data: any = {
             priority: 'high',
+            channel: 'scrypted',
         };
 
         if (typeof media === 'string') {


### PR DESCRIPTION
https://companion.home-assistant.io/docs/notifications/notifications-basic/#notification-channels

This passes through to be a specific notification category (`scrypted`) on Android (I'm not sure how iOS handles these). Prior to this change, the notification comes in on the default Home Assistant Mobile App channel

In the future, the notification type (i.e. motion, person, etc) could be appended to the channel name to allow even more specific notification tuning. I didn't see this data in the `NotifierOptions` object passed in.

Edit: now based on draft https://github.com/koush/scrypted/pull/1625