### PR TITLE
Add EntrySensor support to HaBinarySensor

### DIFF
--- a/src/types/binarySensor.ts
+++ b/src/types/binarySensor.ts
@@ -1,4 +1,4 @@
-import { BinarySensor } from "@scrypted/sdk";
+import { BinarySensor, EntrySensor } from "@scrypted/sdk";
 import { HaBaseDevice } from "./baseDevice";
 import { HaEntityData } from "../utils";
 
@@ -7,11 +7,12 @@ enum HaBinarySensorState {
     Off = 'off'
 }
 
-export class HaBinarySensor extends HaBaseDevice implements BinarySensor {
+export class HaBinarySensor extends HaBaseDevice implements BinarySensor, EntrySensor {
     async updateState(entityData: HaEntityData<HaBinarySensorState>) {
-        const { state } = entityData;
-
-        if (Object.values(HaBinarySensorState).includes(state)) {
+        const { state, attributes } = entityData;
+        if (attributes && (attributes.device_class === 'door' || attributes.device_class === 'garage' || attributes.device_class === 'garage_door')) {
+            this.entryOpen = state === HaBinarySensorState.On;
+        } else {
             this.binaryState = state === HaBinarySensorState.On;
         }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -178,17 +178,31 @@ export const mapSensorEntity = (entity: HaEntityData): DomainMetadata => {
     return domainMetadata;
 }
 
+const doorSensorDeviceClasses = ['door', 'opening', 'garage', 'garage_door'];
+export function isDoorSensor(entity: HaEntityData): boolean {
+    return doorSensorDeviceClasses.includes(entity.attributes?.device_class || '');
+}
+
 export const getDomainMetadata = (entityData: HaEntityData) => {
     const domain = entityData.entity_id.split('.')[0] as HaDomain;
-
+    if (domain === HaDomain.BinarySensor) {
+        if (isDoorSensor(entityData)) {
+            return {
+                type: ScryptedDeviceType.Entry,
+                interfaces: [ScryptedInterface.EntrySensor],
+                nativeIdPrefix: 'haBinaryDoorSensor',
+                deviceConstructor: HaBinarySensor,
+            };
+        }
+        return domainMetadataMap[HaDomain.BinarySensor];
+    }
     if (domain === HaDomain.Sensor) {
         const metadata = mapSensorEntity(entityData);
         if (!metadata) {
             console.log(`Entity not supported: ${entityData.entity_id}, ${JSON.stringify(entityData)}`);
         }
-
         return metadata;
     } else {
         return domainMetadataMap[domain];
     }
-}
+};


### PR DESCRIPTION
Add support for EntrySensor in HaBinarySensor, allowing detection of door-related states based on device classes. 