### PR TITLE
feat: add motion sensor mapping for Home Assistant binary sensors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scrypted/homeassistant",
-  "version": "0.1.16",
+  "version": "0.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@scrypted/homeassistant",
-      "version": "0.1.16",
+      "version": "0.1.15",
       "dependencies": {
         "axios": "^1.7.9",
         "home-assistant-js-websocket": "^9.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scrypted/homeassistant",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@scrypted/homeassistant",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "axios": "^1.7.9",
         "home-assistant-js-websocket": "^9.4.0",

--- a/src/types/binarySensor.ts
+++ b/src/types/binarySensor.ts
@@ -1,4 +1,4 @@
-import { BinarySensor, EntrySensor, FloodSensor, ScryptedDeviceBase } from "@scrypted/sdk";
+import { BinarySensor, EntrySensor, FloodSensor, MotionSensor, ScryptedDeviceBase } from "@scrypted/sdk";
 import { HaBaseDevice } from "./baseDevice";
 import { getBinarySensorType, HaEntityData } from "../utils";
 
@@ -7,10 +7,10 @@ export enum HaBinarySensorState {
     Off = 'off'
 }
 
-export class HaBinarySensor extends HaBaseDevice implements BinarySensor, EntrySensor, FloodSensor {
+export class HaBinarySensor extends HaBaseDevice implements BinarySensor, EntrySensor, FloodSensor, MotionSensor {
     async updateState(entityData: HaEntityData<HaBinarySensorState>) {
         const { state } = entityData;
-        const { isFLoodSensor, isDoorSensor } = getBinarySensorType(entityData);
+        const { isFLoodSensor, isDoorSensor, isMotionSensor } = getBinarySensorType(entityData);
 
         const newState = state === HaBinarySensorState.On ? true :
             state === HaBinarySensorState.Off ? false :
@@ -18,6 +18,7 @@ export class HaBinarySensor extends HaBaseDevice implements BinarySensor, EntryS
 
         const key: keyof ScryptedDeviceBase = isFLoodSensor ? 'flooded' :
             isDoorSensor ? 'entryOpen' :
+            isMotionSensor ? 'motionDetected' :
                 'binaryState'
 
         const currentState = this[key];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,13 +239,15 @@ export const mapSensorEntity = (entity: HaEntityData): DomainMetadata => {
 export const getBinarySensorType = (entity: HaEntityData) => {
     const isFLoodSensor = entity.attributes.device_class === 'moisture';
     const isDoorSensor = ['door', 'opening', 'garage', 'garage_door']
-        .includes(entity.attributes?.device_class || '')
+        .includes(entity.attributes?.device_class || '');
+    const isMotionSensor = ['motion', 'occupancy', 'moving']
+        .includes(entity.attributes?.device_class || '');
 
-    return { isFLoodSensor, isDoorSensor };
+    return { isFLoodSensor, isDoorSensor, isMotionSensor };
 }
 
 export const mapBinarySensorEntity = (entity: HaEntityData): DomainMetadata => {
-    const { isFLoodSensor, isDoorSensor } = getBinarySensorType(entity);
+    const { isFLoodSensor, isDoorSensor, isMotionSensor } = getBinarySensorType(entity);
 
     let domainMetadata: DomainMetadata;
     if (isFLoodSensor) {
@@ -260,6 +262,13 @@ export const mapBinarySensorEntity = (entity: HaEntityData): DomainMetadata => {
             type: ScryptedDeviceType.Entry,
             interfaces: [ScryptedInterface.EntrySensor, ScryptedInterface.BinarySensor],
             nativeIdPrefix: 'haBinaryDoorSensor',
+            deviceConstructor: HaBinarySensor,
+        }
+    } else if (isMotionSensor) {
+        domainMetadata = {
+            type: ScryptedDeviceType.Sensor,
+            interfaces: [ScryptedInterface.MotionSensor, ScryptedInterface.BinarySensor],
+            nativeIdPrefix: 'haBinaryMotionSensor',
             deviceConstructor: HaBinarySensor,
         }
     } else {


### PR DESCRIPTION
- Add motion sensor detection for device_class: motion, occupancy, moving
- Map motion sensors to MotionSensor interface in addition to BinarySensor

Closes #12